### PR TITLE
feat: add --ignore-gitignore flag to bypass gitignore filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ PLAN.md
 *-task.md
 # Coverage check binaries
 tools/coverage-check/coverage-check*
+
+# glance files
+**/glance.md

--- a/lib/handoff.go
+++ b/lib/handoff.go
@@ -50,6 +50,9 @@ type Config struct {
 	// Format is a template string for formatting output, using {path} and {content} placeholders
 	Format string
 
+	// IgnoreGitignore bypasses gitignore filtering when true
+	IgnoreGitignore bool
+
 	// Internal representation of include/exclude patterns
 	includeExts []string
 	excludeExts []string
@@ -128,6 +131,13 @@ func WithExcludeNames(excludeNames string) Option {
 func WithGitClient(gitClient GitClient) Option {
 	return func(c *Config) {
 		c.GitClient = gitClient
+	}
+}
+
+// WithIgnoreGitignore sets whether to ignore gitignore rules.
+func WithIgnoreGitignore(ignoreGitignore bool) Option {
+	return func(c *Config) {
+		c.IgnoreGitignore = ignoreGitignore
 	}
 }
 
@@ -430,8 +440,8 @@ func processFile(filePath string, logger *Logger, config *Config, processor Proc
 		return ""
 	}
 
-	// Check if file is gitignored
-	if isGitIgnored(filePath, config) {
+	// Check if file is gitignored (unless ignoring gitignore rules)
+	if !config.IgnoreGitignore && isGitIgnored(filePath, config) {
 		logger.Verbose("skipping gitignored file: %s", filePath)
 		return ""
 	}

--- a/main.go
+++ b/main.go
@@ -25,10 +25,11 @@ func parseConfig() (*handoff.Config, string, bool, bool) {
 		include       string
 		exclude       string
 		excludeNames  string
-		format        string = "<{path}>\n```\n{content}\n```\n</{path}>\n\n"
+		format        = "<{path}>\n```\n{content}\n```\n</{path}>\n\n"
 		dryRun        bool
 		outputFile    string
 		force         bool
+		ignoreGitignore bool
 	)
 
 	// Define flag bindings
@@ -40,6 +41,7 @@ func parseConfig() (*handoff.Config, string, bool, bool) {
 	flag.StringVar(&format, "format", format, "Custom format for output. Use {path} and {content} as placeholders")
 	flag.StringVar(&outputFile, "output", "", "Write output to the specified file instead of clipboard (e.g., HANDOFF.md)")
 	flag.BoolVar(&force, "force", false, "Allow overwriting existing files when using -output flag")
+	flag.BoolVar(&ignoreGitignore, "ignore-gitignore", false, "Process files even if they are gitignored")
 
 	// Parse command-line flags
 	flag.Parse()
@@ -65,6 +67,10 @@ func parseConfig() (*handoff.Config, string, bool, bool) {
 	
 	if format != "" {
 		options = append(options, handoff.WithFormat(format))
+	}
+	
+	if ignoreGitignore {
+		options = append(options, handoff.WithIgnoreGitignore(ignoreGitignore))
 	}
 	
 	config := handoff.NewConfig(options...)


### PR DESCRIPTION
## Summary
- Adds `--ignore-gitignore` CLI flag to process files that would normally be skipped due to gitignore rules
- Enables use cases like processing `glance.md` files for documentation or AI context gathering

## Test plan
- [x] Verify new CLI flag appears in help output
- [x] Test flag bypasses gitignore filtering for individual files
- [x] Test flag works with multiple files via find command
- [x] Confirm existing tests still pass
- [x] Verify backward compatibility (default behavior unchanged)